### PR TITLE
Bluebird fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,13 +45,13 @@ class FetchHandler {
       const dataset = this.dataset.match(null, null, null, rdf.namedNode(req.iri))
 
       if (dataset.length === 0) {
-        return next()
+        return
       }
 
       const graph = rdf.graph(dataset)
 
       return res.graph(graph)
-    }).catch(next)
+    }).asCallback(next)
   }
 
   // legacy interface

--- a/lib/Fetcher.js
+++ b/lib/Fetcher.js
@@ -34,9 +34,6 @@ class Fetcher {
       if (options.contentType) {
         res.headers.set('content-type', options.contentType)
       }
-
-      return res
-    }).then((res) => {
       options.fetched = new Date()
 
       return res.dataset()


### PR DESCRIPTION
Before this PR, Bluebird keeps showing this warning:

> Warning: a promise was created in a handler at […]/trifid-handler-fetch/index.js:48:16 but
> was not returned from it, see http://goo.gl/rRqMUw

There's an explanation here: https://code.i-harness.com/en/q/25caebb , it comes down to mixing
Promise-based interfaces (here the handler) and callback-based interfaces (here the express
middleware).
