### PR TITLE
Use @rdfjs/fetch instead of rdf-fetch

### DIFF
--- a/lib/Fetcher.js
+++ b/lib/Fetcher.js
@@ -1,7 +1,7 @@
 import fileFetch from 'file-fetch'
 import protoFetch from 'proto-fetch'
 import rdf from 'rdf-ext'
-import rdfFetch from 'rdf-fetch'
+import rdfFetch from '@rdfjs/fetch'
 import splitIntoGraphs from './spread/splitIntoGraphs.js'
 
 const fetch = protoFetch({
@@ -25,18 +25,16 @@ class Fetcher {
     })
   }
 
-  static fetchDataset (options) {
+  static async fetchDataset (options) {
     options.options = options.options || {}
     options.options.fetch = fetch
 
-    return rdfFetch(options.url, options.options).then((res) => {
-      if (options.contentType) {
-        res.headers.set('content-type', options.contentType)
-      }
-      options.fetched = new Date()
-
-      return res.dataset()
-    })
+    const res = await rdfFetch(options.url, options.options)
+    if (options.contentType) {
+      res.headers.set('content-type', options.contentType)
+    }
+    options.fetched = new Date()
+    return res.dataset()
   }
 
   static spreadDataset (inputDataset, outputDataset, options) {
@@ -57,16 +55,15 @@ class Fetcher {
     return outputDataset
   }
 
-  static load (dataset, options) {
+  static async load (dataset, options) {
     if (Fetcher.isCached(options)) {
       return Promise.resolve()
     }
 
     Fetcher.clearDataset(dataset, options)
 
-    return Fetcher.fetchDataset(options).then((input) => {
-      return Fetcher.spreadDataset(input, dataset, options)
-    })
+    const input = await Fetcher.fetchDataset(options)
+    return Fetcher.spreadDataset(input, dataset, options)
   }
 }
 

--- a/lib/Fetcher.js
+++ b/lib/Fetcher.js
@@ -29,7 +29,10 @@ class Fetcher {
     options.options = options.options || {}
     options.options.fetch = fetch
 
-    const res = await rdfFetch(options.url, options.options)
+    const res = await rdfFetch(options.url, {
+      ...options.options,
+      factory: rdf
+    })
     if (options.contentType) {
       res.headers.set('content-type', options.contentType)
     }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@rdfjs/formats-common": "^2.2.0",
     "@rdfjs/serializer-jsonld-ext": "^3.0.0",
     "file-fetch": "^1.7.0",
-    "rdf-fetch": "^1.0.0",
+    "@rdfjs/fetch": "^3.1.0",
     "nodeify-fetch": "^3.0.0",
     "proto-fetch": "^1.0.0",
     "rdf-ext": "^2.0.1",

--- a/test/Fetcher.js
+++ b/test/Fetcher.js
@@ -8,10 +8,10 @@ import Fetcher from '../lib/Fetcher.js'
 
 import { createRequire } from 'module'
 
-const require = createRequire(import.meta.url) // eslint-disable-line
+const require = createRequire(import.meta.url)
 
 describe('Fetcher', () => {
-  const fileUrlDataset = 'file://' + require.resolve('tbbt-ld/dist/tbbt.nq')
+  const fileUrlDataset = `file://${require.resolve('tbbt-ld/dist/tbbt.nq')}`
 
   describe('.isCached', () => {
     it('should be a method', () => {
@@ -39,7 +39,7 @@ describe('Fetcher', () => {
       assert.equal(typeof Fetcher.fetchDataset, 'function')
     })
 
-    it('should load a dataset from a file URL', () => {
+    it('should load a dataset from a file URL', async () => {
       const options = {
         url: fileUrlDataset,
         options: {
@@ -49,19 +49,16 @@ describe('Fetcher', () => {
         }
       }
 
-      return Fetcher.fetchDataset(options).then((dataset) => {
-        const graphs = dataset.toArray().reduce((graphs, quad) => {
-          graphs[quad.graph.value] = true
-
-          return graphs
-        }, {})
-
-        assert(graphs['http://localhost:8080/data/person/amy-farrah-fowler'])
-        assert(graphs['http://localhost:8080/data/person/sheldon-cooper'])
-      })
+      const dataset = await Fetcher.fetchDataset(options)
+      const graphs = Array.from(dataset).reduce((graph, quad) => {
+        graph[quad.graph.value] = true
+        return graph
+      }, {})
+      assert(graphs['http://localhost:8080/data/person/amy-farrah-fowler'])
+      assert(graphs['http://localhost:8080/data/person/sheldon-cooper'])
     })
 
-    it('should load a dataset from a http URL', () => {
+    it('should load a dataset from a http URL', async () => {
       const content = fs.readFileSync(new URL(fileUrlDataset))
 
       nock('http://example.org').get('/dataset').reply(200, content, {
@@ -72,19 +69,16 @@ describe('Fetcher', () => {
         url: 'http://example.org/dataset'
       }
 
-      return Fetcher.fetchDataset(options).then((dataset) => {
-        const graphs = dataset.toArray().reduce((graphs, quad) => {
-          graphs[quad.graph.value] = true
-
-          return graphs
-        }, {})
-
-        assert(graphs['http://localhost:8080/data/person/amy-farrah-fowler'])
-        assert(graphs['http://localhost:8080/data/person/sheldon-cooper'])
-      })
+      const dataset = await Fetcher.fetchDataset(options)
+      const graphs = Array.from(dataset).reduce((graph, quad) => {
+        graph[quad.graph.value] = true
+        return graph
+      }, {})
+      assert(graphs['http://localhost:8080/data/person/amy-farrah-fowler'])
+      assert(graphs['http://localhost:8080/data/person/sheldon-cooper'])
     })
 
-    it('should load a dataset from a http URL and use the given content type to parse it', () => {
+    it('should load a dataset from a http URL and use the given content type to parse it', async () => {
       const content = fs.readFileSync(new URL(fileUrlDataset))
 
       nock('http://example.org').get('/dataset-content-type').reply(200, content)
@@ -94,16 +88,13 @@ describe('Fetcher', () => {
         contentType: 'application/n-quads'
       }
 
-      return Fetcher.fetchDataset(options).then((dataset) => {
-        const graphs = dataset.toArray().reduce((graphs, quad) => {
-          graphs[quad.graph.value] = true
-
-          return graphs
-        }, {})
-
-        assert(graphs['http://localhost:8080/data/person/amy-farrah-fowler'])
-        assert(graphs['http://localhost:8080/data/person/sheldon-cooper'])
-      })
+      const dataset = await Fetcher.fetchDataset(options)
+      const graphs = Array.from(dataset).reduce((graph, quad) => {
+        graph[quad.graph.value] = true
+        return graph
+      }, {})
+      assert(graphs['http://localhost:8080/data/person/amy-farrah-fowler'])
+      assert(graphs['http://localhost:8080/data/person/sheldon-cooper'])
     })
   })
 

--- a/test/Fetcher.js
+++ b/test/Fetcher.js
@@ -81,7 +81,10 @@ describe('Fetcher', () => {
     it('should load a dataset from a http URL and use the given content type to parse it', async () => {
       const content = fs.readFileSync(new URL(fileUrlDataset))
 
-      nock('http://example.org').get('/dataset-content-type').reply(200, content)
+      nock('http://example.org').get('/dataset-content-type')
+        .reply(200, content, {
+          'content-type': 'text/turtle'
+        })
 
       const options = {
         url: 'http://example.org/dataset-content-type',


### PR DESCRIPTION
The `rdf-fetch` package is deprecated and contains many vulnerabilities.
We should use `@rdfjs/fetch` instead.